### PR TITLE
Add dockerfile for building triton module for jp6 via igpu containers

### DIFF
--- a/bin/viam-mlmodelservice-triton.sh.envsubst
+++ b/bin/viam-mlmodelservice-triton.sh.envsubst
@@ -14,4 +14,4 @@ exec docker run \
      -v ${DOLLAR}SOCKET_DIR:${DOLLAR}SOCKET_DIR \
      -v ${DOLLAR}VIAM_DIR:${DOLLAR}VIAM_DIR \
      $TAG \
-     sudo -u \#$(id -u) LD_PRELOAD=libjemalloc.so.2 /opt/viam/bin/viam_mlmodelservice_triton "$@"
+     sudo -u \#$(id -u) LD_PRELOAD=libjemalloc.so.2 /opt/viam/bin/viam_mlmodelservice_triton "$@" 2>&1

--- a/etc/docker/Dockerfile.nvcr-triton-containers
+++ b/etc/docker/Dockerfile.nvcr-triton-containers
@@ -1,0 +1,78 @@
+ARG TRITON_VERSION=24.06
+ARG JETPACK
+
+FROM nvcr.io/nvidia/tritonserver:${TRITON_VERSION}-py3${JETPACK:+-igpu}-sdk AS nvidia-triton-build-base
+FROM nvcr.io/nvidia/tritonserver:${TRITON_VERSION}-py3${JETPACK:+-igpu} AS nvidia-triton-runtime-base
+
+FROM nvidia-triton-build-base AS build-deps
+ENV DEBIAN_FRONTEND=noninteractive
+ENV HOME=/root
+
+# Create directories we will use
+RUN mkdir -p ${HOME}/opt/src
+
+RUN apt-get -y update && apt-get -y --no-install-recommends install \
+    ca-certificates \
+    gnupg
+
+RUN apt-key adv --fetch-key https://apt.kitware.com/keys/kitware-archive-latest.asc
+RUN echo 'deb https://apt.kitware.com/ubuntu/ jammy main' > /etc/apt/sources.list.d/kitware.list
+
+RUN apt-get -y update && apt-get -y --no-install-recommends install \
+    cmake \
+    git \
+    libabsl-dev \
+    libboost-all-dev \
+    libgrpc++-dev \
+    libprotobuf-dev \
+    ninja-build \
+    protobuf-compiler \
+    protobuf-compiler-grpc \
+    rapidjson-dev
+
+# Clone, build, and install the viam-cpp-sdk repo
+RUN mkdir -p ${HOME}/opt/src
+RUN cd ${HOME}/opt/src && \
+    git clone https://github.com/viamrobotics/viam-cpp-sdk.git -b releases/v0.0.9 && \
+    cd viam-cpp-sdk && \
+    cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH=/opt/viam && \
+    PATH=/opt/viam/bin:$PATH cmake --build build --target install -j3 -- -v && \
+    cmake --install build --prefix /opt/viam
+
+RUN mkdir -p /opt/tritonserver/include
+RUN ln -s /workspace/install/include/triton /opt/tritonserver/include/triton
+RUN ln -s /workspace/install/lib/stubs /opt/tritonserver/lib
+
+FROM build-deps AS build
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Build and install the Viam Triton MLModelService from our
+# local state against the C++ SDK and Triton Server
+ADD . ${HOME}/opt/src/viam-mlmodelservice-triton
+RUN \
+    cd ${HOME}/opt/src/viam-mlmodelservice-triton && \
+    cmake -S . -B build -G Ninja \
+      -DVIAM_MLMODELSERVICE_TRITON_TRITONSERVER_ROOT=/opt/tritonserver \
+      -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+      -DCMAKE_PREFIX_PATH=/opt/viam && \
+    cmake --build build --target install -- -v && \
+    cmake --install build --prefix /opt/viam
+
+
+FROM nvidia-triton-runtime-base AS runtime
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get -y update && apt-get -y --no-install-recommends install \
+    ca-certificates \
+    gnupg
+
+RUN apt-get -y update && apt-get -y --no-install-recommends install \
+    libboost-log1.74.0 \
+    libjemalloc2 \
+    libabsl20210324 \
+    libgrpc++1 \
+    libprotobuf23
+
+FROM runtime AS deploy
+ENV DEBIAN_FRONTEND=noninteractive
+COPY --from=build /opt/viam /opt/viam

--- a/etc/docker/Dockerfile.nvcr-triton-containers
+++ b/etc/docker/Dockerfile.nvcr-triton-containers
@@ -35,8 +35,12 @@ RUN mkdir -p ${HOME}/opt/src
 RUN cd ${HOME}/opt/src && \
     git clone https://github.com/viamrobotics/viam-cpp-sdk.git -b releases/v0.0.11 && \
     cd viam-cpp-sdk && \
-    cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH=/opt/viam && \
-    PATH=/opt/viam/bin:$PATH cmake --build build --target install -j3 -- -v && \
+    cmake -S . -B build -G Ninja \
+      -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+      -DCMAKE_PREFIX_PATH=/opt/viam \
+      -DVIAMCPPSDK_BUILD_EXAMPLES=OFF \
+      -DVIAMCPPSDK_BUILD_TESTS=OFF && \
+    PATH=/opt/viam/bin:$PATH cmake --build build --target install -- -v && \
     cmake --install build --prefix /opt/viam
 
 RUN mkdir -p /opt/tritonserver/include

--- a/etc/docker/Dockerfile.nvcr-triton-containers
+++ b/etc/docker/Dockerfile.nvcr-triton-containers
@@ -64,7 +64,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get -y update && apt-get -y --no-install-recommends install \
     ca-certificates \
-    gnupg
+    gnupg \
+    sudo
 
 RUN apt-get -y update && apt-get -y --no-install-recommends install \
     libboost-log1.74.0 \

--- a/etc/docker/Dockerfile.nvcr-triton-containers
+++ b/etc/docker/Dockerfile.nvcr-triton-containers
@@ -1,4 +1,4 @@
-ARG TRITON_VERSION=24.06
+ARG TRITON_VERSION=24.09
 ARG JETPACK
 
 FROM nvcr.io/nvidia/tritonserver:${TRITON_VERSION}-py3${JETPACK:+-igpu}-sdk AS nvidia-triton-build-base
@@ -33,7 +33,7 @@ RUN apt-get -y update && apt-get -y --no-install-recommends install \
 # Clone, build, and install the viam-cpp-sdk repo
 RUN mkdir -p ${HOME}/opt/src
 RUN cd ${HOME}/opt/src && \
-    git clone https://github.com/viamrobotics/viam-cpp-sdk.git -b releases/v0.0.9 && \
+    git clone https://github.com/viamrobotics/viam-cpp-sdk.git -b releases/v0.0.11 && \
     cd viam-cpp-sdk && \
     cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH=/opt/viam && \
     PATH=/opt/viam/bin:$PATH cmake --build build --target install -j3 -- -v && \

--- a/etc/docker/Dockerfile.triton-jetpack-focal
+++ b/etc/docker/Dockerfile.triton-jetpack-focal
@@ -115,8 +115,12 @@ RUN cd ${HOME}/opt/src && \
 RUN cd ${HOME}/opt/src && \
     git clone https://github.com/viamrobotics/viam-cpp-sdk.git -b releases/v0.0.11 && \
     cd viam-cpp-sdk && \
-    cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH=/opt/viam && \
-    PATH=/opt/viam/bin:$PATH cmake --build build --target install -j3 -- -v && \
+    cmake -S . -B build -G Ninja \
+      -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+      -DCMAKE_PREFIX_PATH=/opt/viam \
+      -DVIAMCPPSDK_BUILD_EXAMPLES=OFF \
+      -DVIAMCPPSDK_BUILD_TESTS=OFF && \
+    PATH=/opt/viam/bin:$PATH cmake --build build --target install -- -v && \
     cmake --install build --prefix /opt/viam
 
 # Download and install the jetpack build of TritonServer and install it to /opt/tritonserver

--- a/etc/docker/Dockerfile.triton-jetpack-focal
+++ b/etc/docker/Dockerfile.triton-jetpack-focal
@@ -96,7 +96,7 @@ RUN apt-get -y update && apt-get -y --no-install-recommends install \
 
 # Build grpc (and proto, etc.) from source, since we don't have a good version on focal
 RUN cd ${HOME}/opt/src && \
-    git clone --recurse-submodules -b v1.65.0 --depth 1 --shallow-submodules https://github.com/grpc/grpc && \
+    git clone --recurse-submodules -b v1.66.2 --depth 1 --shallow-submodules https://github.com/grpc/grpc && \
     cd grpc && \
     cmake -S . -B build -G Ninja \
         -DgRPC_CARES_PROVIDER=package \
@@ -113,7 +113,7 @@ RUN cd ${HOME}/opt/src && \
 
 # Clone, build, and install the viam-cpp-sdk repo
 RUN cd ${HOME}/opt/src && \
-    git clone https://github.com/viamrobotics/viam-cpp-sdk.git -b releases/v0.0.9 && \
+    git clone https://github.com/viamrobotics/viam-cpp-sdk.git -b releases/v0.0.11 && \
     cd viam-cpp-sdk && \
     cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH=/opt/viam && \
     PATH=/opt/viam/bin:$PATH cmake --build build --target install -j3 -- -v && \

--- a/etc/docker/Dockerfile.triton-jetpack-focal
+++ b/etc/docker/Dockerfile.triton-jetpack-focal
@@ -1,5 +1,5 @@
 FROM ubuntu:focal AS base
-ARG DEBIAN_FRONTEND=noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Add components needed for apt-key / apt-add-repository, since
 # we need to have the JetPack repo available for both build and runtime
@@ -16,7 +16,7 @@ RUN echo 'deb https://repo.download.nvidia.com/jetson/common r35.5 main' > /etc/
 
 
 FROM base AS runtime
-ARG DEBIAN_FRONTEND=noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Hack to get PVA stuff to install
 RUN mkdir -p /lib/firmware
@@ -59,7 +59,7 @@ RUN apt-get -y update && apt-get -y --no-install-recommends install \
 # are expensive, and it is unfortunate to need to re-execute them if
 # just the Viam triton server build itself fails.
 FROM base AS build-deps
-ARG DEBIAN_FRONTEND=noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 ENV HOME=/root
 
 # Create directories we will use
@@ -126,7 +126,7 @@ RUN chmod -R oug+rX /opt/tritonserver/
 
 
 FROM build-deps AS build
-ARG DEBIAN_FRONTEND=noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Build and install the Viam Triton MLModelService from our
 # local state against the C++ SDK and Triton Server
@@ -142,7 +142,7 @@ RUN \
 
 
 FROM runtime AS deploy
-ARG DEBIAN_FRONTEND=noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 COPY --from=build /opt/viam /opt/viam
 COPY --from=build /opt/tritonserver /opt/tritonserver


### PR DESCRIPTION
I've tested that this builds both with and without `JETPACK=1`, but since I do not have a JP 6 device at the moment, I haven't tested running them. Still, it seemed better to get this work merged so it can form a basis for continuing work on JP6.