### PR TITLE
use the original module name: making a new one has model name conflicts

### DIFF
--- a/meta.json
+++ b/meta.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://dl.viam.dev/module.schema.json",
-  "module_id": "viam:mlmodelservice-triton",
+  "module_id": "viam:mlmodelservice-triton-jetpack",
   "visibility": "public",
   "url": "https://github.com/viamrobotics/viam-mlmodelservice-triton",
   "description": "Viam Triton Inference Server Module",


### PR DESCRIPTION
One of these days I'll get it right.

With the old name, we had errors publishing to the registry because there were model name conflicts between two modules (the original name and the new one that didn't mention Jetpack). Ideally, we'll rename this module to not mention Jetpack, since you can now run it without it.