### PR TITLE
bugfix: don't do env var substitution until the module starts

### DIFF
--- a/bin/viam-mlmodelservice-triton.sh.envsubst
+++ b/bin/viam-mlmodelservice-triton.sh.envsubst
@@ -18,4 +18,4 @@ exec docker run \
      -v ${DOLLAR}SOCKET_DIR:${DOLLAR}SOCKET_DIR \
      -v ${DOLLAR}VIAM_DIR:${DOLLAR}VIAM_DIR \
      $TAG \
-     sudo -u \#$(id -u) LD_PRELOAD=libjemalloc.so.2 VIAM_MODULE_DATA="$VIAM_MODULE_DATA" /opt/viam/bin/viam_mlmodelservice_triton "$@" 2>&1
+     sudo -u \#$(id -u) LD_PRELOAD=libjemalloc.so.2 VIAM_MODULE_DATA="${DOLLAR}VIAM_MODULE_DATA" /opt/viam/bin/viam_mlmodelservice_triton "$@" 2>&1


### PR DESCRIPTION
Otherwise, the env var gets substituted in when the makefile creates the .sh script, back when we're deploying the new module version.