### PR TITLE
[RSDK-9279] Add first_run.sh to pull docker image

### DIFF
--- a/Makefile.module
+++ b/Makefile.module
@@ -4,7 +4,11 @@ viam-mlmodelservice-triton.sh: bin/viam-mlmodelservice-triton.sh.envsubst
 	cat $< | TAG=$(TAG) DOLLAR=$$ envsubst > $@
 	chmod +x $@
 
-module.tar.gz: viam-mlmodelservice-triton.sh
+first_run.sh: bin/first_run.sh.envsubst
+	cat $< | TAG=$(TAG) DOLLAR=$$ envsubst > $@
+	chmod +x $@
+
+module.tar.gz: viam-mlmodelservice-triton.sh first_run.sh
 	tar czf $@ $^
 
 .PHONY: module.tar.gz

--- a/Makefile.module
+++ b/Makefile.module
@@ -1,10 +1,6 @@
 TAG ?= ghcr.io/USER/REPO:0.0.0
 
-viam-mlmodelservice-triton.sh: bin/viam-mlmodelservice-triton.sh.envsubst
-	cat $< | TAG=$(TAG) DOLLAR=$$ envsubst > $@
-	chmod +x $@
-
-first_run.sh: bin/first_run.sh.envsubst
+%.sh: bin/%.sh.envsubst
 	cat $< | TAG=$(TAG) DOLLAR=$$ envsubst > $@
 	chmod +x $@
 

--- a/bin/first_run.sh.envsubst
+++ b/bin/first_run.sh.envsubst
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# The docker image is so large that we likely cannot grab the whole thing while initializing the
+# module without us getting killed and restarted. So, download the image before we even attempt to
+# start up.
+# We use `exec` to have this process "become" `docker pull`. That way, if viam-server tries to kill
+# us, it kills the correct process.
+exec docker pull $TAG

--- a/bin/first_run.sh.envsubst
+++ b/bin/first_run.sh.envsubst
@@ -4,6 +4,7 @@ set -euxo pipefail
 # The docker image is so large that we likely cannot grab the whole thing while initializing the
 # module without us getting killed and restarted. So, download the image before we even attempt to
 # start up.
+
 # We use `exec` to have this process "become" `docker pull`. That way, if viam-server tries to kill
 # us, it kills the correct process.
 exec docker pull $TAG

--- a/bin/viam-mlmodelservice-triton.sh.envsubst
+++ b/bin/viam-mlmodelservice-triton.sh.envsubst
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -euxo pipefail
 
 SOCKET_DIR=`dirname $1`
 VIAM_DIR=`realpath ~/.viam`
 
 # TODO: Validate presence of NVidia container runtime
+
+# We use `exec` to "become" the docker command. That way, stdout and stderr from the docker command
+# connect to viam-server correctly, and viam-server is able to kill the docker container if needed.
 
 # Sneaky trick alert: we need to get $VIAM_MODULE_DATA propagated into the actual server. If we set
 # the environment variable using a `-e` flag on the docker command, it would be set for the command

--- a/meta.json
+++ b/meta.json
@@ -10,5 +10,6 @@
       "model": "viam:mlmodelservice:triton"
     }
   ],
-  "entrypoint": "viam-mlmodelservice-triton.sh"
+  "entrypoint": "viam-mlmodelservice-triton.sh",
+  "first_run": "first_run.sh"
 }


### PR DESCRIPTION
Things I have tried:
- `make module.tar.gz` constructs a shell script using the correct tag, and includes the shell script in the .tar.gz file.
- Running that shell script starts downloading docker images. I got impatient and stopped it before it finished

Things I have not tried:
- Running the module through `viam-server` to see if it invokes `first_run.sh` the way it should. If it's a local module, it's unclear to me how `viam-server` knows about `first_run.sh`, and if it's not a local module, I need to upload to the registry first.

Unrelated to the main change: I added a `set -x` (print out every command in the shell script before you run it), for ease in debugging stuff. 