### PR TITLE
More make targets

### DIFF
--- a/Makefile.module
+++ b/Makefile.module
@@ -1,10 +1,30 @@
-TAG ?= ghcr.io/USER/REPO:0.0.0
+URL ?= ghcr.io/USER/REPO
+SEMVER ?= 0.0.0
+TAG ?= $(URL)$(SUFFIX):$(SEMVER)
 
 %.sh: bin/%.sh.envsubst
 	cat $< | TAG=$(TAG) DOLLAR=$$ envsubst > $@
 	chmod +x $@
 
+# Docker containers
+.PHONY: containers container-jetpack5 container-jetpack6 container-cuda
+containers: container-jetpack5 container-jetpack6 container-cuda
+
+container-jetpack5:
+	TAG ?= $(URL)/jetpack5:$(SEMVER)
+	docker build . -t $(TAG) -f etc/docker/Dockerfile.triton-jetpack-focal
+
+container-jetpack6:
+	TAG ?= $(URL)/jetpack6:$(SEMVER)
+	docker build . -t $(TAG) -f etc/docker/Dockerfile.nvcr-triton-containers --build-arg JETPACK=1
+
+container-cuda:
+	TAG ?= $(URL)/cuda:$(SEMVER)
+	docker build . -t $(TAG) -f etc/docker/Dockerfile.nvcr-triton-containers
+
+
+.PHONY: module.tar.gz
 module.tar.gz: viam-mlmodelservice-triton.sh first_run.sh
 	tar czf $@ $^
 
-.PHONY: module.tar.gz
+default: containers module.tar.gz

--- a/Makefile.module
+++ b/Makefile.module
@@ -2,16 +2,20 @@ URL ?= ghcr.io/USER/REPO
 SEMVER ?= 0.0.0
 TAG ?= $(URL)$(SUFFIX):$(SEMVER)
 
+
 # Shell scripts built with environment variable substitution should be declared .PHONY, because
 # they need to be rebuilt even if the only thing that's changed is the value of $(TAG). We declare
 # them in separate rules because one rule for `%.sh` doesn't work with .PHONY.
 .PHONY: viam-mlmodelservice-triton.sh first_run.sh
+
 first_run.sh: bin/first_run.sh.envsubst
 	cat $< | TAG=$(TAG) DOLLAR=$$ envsubst > $@
 	chmod +x $@
+
 viam-mlmodelservice-triton.sh: bin/viam-mlmodelservice-triton.sh.envsubst
 	cat $< | TAG=$(TAG) DOLLAR=$$ envsubst > $@
 	chmod +x $@
+
 
 # Docker images. These should be phony because you can't see the files that get built.
 .PHONY: images image-jetpack5 image-jetpack6 image-cuda
@@ -33,7 +37,6 @@ image-cuda:
 # The module itself. Make this target phony because we need to rebuild the files even if the only
 # thing that changes is the TAG.
 .PHONY: module.tar.gz
-
 module.tar.gz: viam-mlmodelservice-triton.sh first_run.sh
 	tar czf $@ $^
 

--- a/Makefile.module
+++ b/Makefile.module
@@ -7,20 +7,20 @@ TAG ?= $(URL)$(SUFFIX):$(SEMVER)
 	cat $< | TAG=$(TAG) DOLLAR=$$ envsubst > $@
 	chmod +x $@
 
-# Docker containers
-.PHONY: containers container-jetpack5 container-jetpack6 container-cuda
-containers: container-jetpack5 container-jetpack6 container-cuda
+# Docker images
+.PHONY: images image-jetpack5 image-jetpack6 image-cuda
+images: image-jetpack5 image-jetpack6 image-cuda
 
-container-jetpack5: SUFFIX ?= /jetpack5
-container-jetpack5:
+image-jetpack5: SUFFIX ?= /jetpack5
+image-jetpack5:
 	docker build . -t $(TAG) -f etc/docker/Dockerfile.triton-jetpack-focal
 
-container-jetpack6: SUFFIX ?= /jetpack6
-container-jetpack6:
+image-jetpack6: SUFFIX ?= /jetpack6
+image-jetpack6:
 	docker build . -t $(TAG) -f etc/docker/Dockerfile.nvcr-triton-containers --build-arg JETPACK=1
 
-container-cuda: SUFFIX ?= /cuda
-container-cuda:
+image-cuda: SUFFIX ?= /cuda
+image-cuda:
 	docker build . -t $(TAG) -f etc/docker/Dockerfile.nvcr-triton-containers
 
 
@@ -40,4 +40,4 @@ module-cuda.tar.gz: SUFFIX ?= /cuda
 module-cuda.tar.gz: viam-mlmodelservice-triton.sh first_run.sh
 	tar czf $@ $^
 
-default: container-jetpack6 module-jetpack6.tar.gz
+default: image-jetpack6 module-jetpack6.tar.gz

--- a/Makefile.module
+++ b/Makefile.module
@@ -1,4 +1,4 @@
-URL ?= ghcr.io/USER/REPO
+URL ?= local-triton-build
 SEMVER ?= 0.0.0
 TAG ?= $(URL)$(SUFFIX):$(SEMVER)
 

--- a/Makefile.module
+++ b/Makefile.module
@@ -24,20 +24,24 @@ image-cuda:
 	docker build . -t $(TAG) -f etc/docker/Dockerfile.nvcr-triton-containers
 
 
-# The module itself. Make these targets phony so they get rebuilt even if all you change is the
-# docker tag.
-.PHONY: module-jetpack5.tar.gz module-jetpack6.tar.gz module-cuda.tar.gz
+# The module itself. Make this target phony because we need to rebuild the files even if the only
+# thing that changes is the TAG.
+.PHONY: module.tar.gz
 
-module-jetpack5.tar.gz: SUFFIX ?= /jetpack5
-module-jetpack5.tar.gz: viam-mlmodelservice-triton.sh first_run.sh
+module.tar.gz: viam-mlmodelservice-triton.sh first_run.sh
 	tar czf $@ $^
 
-module-jetpack6.tar.gz: SUFFIX ?= /jetpack6
-module-jetpack6.tar.gz: viam-mlmodelservice-triton.sh first_run.sh
-	tar czf $@ $^
+# Helpers for building the module easily. These targets are phony because the files built don't
+# match the target names (it's always module.tar.gz).
+.PHONY: module-jetpack5 module-jetpack6 module-cuda
 
-module-cuda.tar.gz: SUFFIX ?= /cuda
-module-cuda.tar.gz: viam-mlmodelservice-triton.sh first_run.sh
-	tar czf $@ $^
+module-jetpack5: SUFFIX ?= /jetpack5
+module-jetpack5: module.tar.gz
 
-default: image-jetpack6 module-jetpack6.tar.gz
+module-jetpack6: SUFFIX ?= /jetpack6
+module-jetpack6: module.tar.gz
+
+module-cuda: SUFFIX ?= /cuda
+module-cuda: module.tar.gz
+
+default: image-jetpack6 module-jetpack6

--- a/Makefile.module
+++ b/Makefile.module
@@ -2,6 +2,7 @@ URL ?= ghcr.io/USER/REPO
 SEMVER ?= 0.0.0
 TAG ?= $(URL)$(SUFFIX):$(SEMVER)
 
+# Shell scripts built with environment variable substitution
 %.sh: bin/%.sh.envsubst
 	cat $< | TAG=$(TAG) DOLLAR=$$ envsubst > $@
 	chmod +x $@
@@ -23,8 +24,19 @@ container-cuda:
 	docker build . -t $(TAG) -f etc/docker/Dockerfile.nvcr-triton-containers
 
 
-.PHONY: module.tar.gz
-module.tar.gz: viam-mlmodelservice-triton.sh first_run.sh
+# The module itself
+.PHONY: module-jetpack5.tar.gz module-jetpack6.tar.gz module-cuda.tar.gz
+
+module-jetpack5.tar.gz: TAG ?= $(URL)/jetpack5:$(SEMVER)
+module-jetpack5.tar.gz: viam-mlmodelservice-triton.sh first_run.sh
 	tar czf $@ $^
 
-default: containers module.tar.gz
+module-jetpack6.tar.gz: TAG ?= $(URL)/jetpack6:$(SEMVER)
+module-jetpack6.tar.gz: viam-mlmodelservice-triton.sh first_run.sh
+	tar czf $@ $^
+
+module-cuda.tar.gz: TAG ?= $(URL)/cuda:$(SEMVER)
+module-cuda.tar.gz: viam-mlmodelservice-triton.sh first_run.sh
+	tar czf $@ $^
+
+default: container-jetpack6 module-jetpack6.tar.gz

--- a/Makefile.module
+++ b/Makefile.module
@@ -34,9 +34,7 @@ image-cuda:
 	docker build . -t $(TAG) -f etc/docker/Dockerfile.nvcr-triton-containers
 
 
-# The module itself. Make this target phony because we need to rebuild the files even if the only
-# thing that changes is the TAG.
-.PHONY: module.tar.gz
+# The module itself.
 module.tar.gz: viam-mlmodelservice-triton.sh first_run.sh
 	tar czf $@ $^
 

--- a/Makefile.module
+++ b/Makefile.module
@@ -2,7 +2,9 @@ URL ?= ghcr.io/USER/REPO
 SEMVER ?= 0.0.0
 TAG ?= $(URL)$(SUFFIX):$(SEMVER)
 
-# Shell scripts built with environment variable substitution
+# Shell scripts built with environment variable substitution. These need to be declared phony, so
+# they get rebuilt even if they already exist and the only thing that has changed is $TAG.
+.PHONY: viam-mlmodelservice-triton.sh first_run.sh
 %.sh: bin/%.sh.envsubst
 	cat $< | TAG=$(TAG) DOLLAR=$$ envsubst > $@
 	chmod +x $@

--- a/Makefile.module
+++ b/Makefile.module
@@ -7,7 +7,7 @@ TAG ?= $(URL)$(SUFFIX):$(SEMVER)
 	cat $< | TAG=$(TAG) DOLLAR=$$ envsubst > $@
 	chmod +x $@
 
-# Docker images
+# Docker images. These should be phony because you can't see the files that get built.
 .PHONY: images image-jetpack5 image-jetpack6 image-cuda
 images: image-jetpack5 image-jetpack6 image-cuda
 

--- a/Makefile.module
+++ b/Makefile.module
@@ -24,18 +24,19 @@ container-cuda:
 	docker build . -t $(TAG) -f etc/docker/Dockerfile.nvcr-triton-containers
 
 
-# The module itself
+# The module itself. Make these targets phony so they get rebuilt even if all you change is the
+# docker tag.
 .PHONY: module-jetpack5.tar.gz module-jetpack6.tar.gz module-cuda.tar.gz
 
-module-jetpack5.tar.gz: TAG ?= $(URL)/jetpack5:$(SEMVER)
+module-jetpack5.tar.gz: SUFFIX ?= /jetpack5
 module-jetpack5.tar.gz: viam-mlmodelservice-triton.sh first_run.sh
 	tar czf $@ $^
 
-module-jetpack6.tar.gz: TAG ?= $(URL)/jetpack6:$(SEMVER)
+module-jetpack6.tar.gz: SUFFIX ?= /jetpack6
 module-jetpack6.tar.gz: viam-mlmodelservice-triton.sh first_run.sh
 	tar czf $@ $^
 
-module-cuda.tar.gz: TAG ?= $(URL)/cuda:$(SEMVER)
+module-cuda.tar.gz: SUFFIX ?= /cuda
 module-cuda.tar.gz: viam-mlmodelservice-triton.sh first_run.sh
 	tar czf $@ $^
 

--- a/Makefile.module
+++ b/Makefile.module
@@ -2,10 +2,14 @@ URL ?= ghcr.io/USER/REPO
 SEMVER ?= 0.0.0
 TAG ?= $(URL)$(SUFFIX):$(SEMVER)
 
-# Shell scripts built with environment variable substitution. These need to be declared phony, so
-# they get rebuilt even if they already exist and the only thing that has changed is $TAG.
+# Shell scripts built with environment variable substitution should be declared .PHONY, because
+# they need to be rebuilt even if the only thing that's changed is the value of $(TAG). We declare
+# them in separate rules because one rule for `%.sh` doesn't work with .PHONY.
 .PHONY: viam-mlmodelservice-triton.sh first_run.sh
-%.sh: bin/%.sh.envsubst
+first_run.sh: bin/first_run.sh.envsubst
+	cat $< | TAG=$(TAG) DOLLAR=$$ envsubst > $@
+	chmod +x $@
+viam-mlmodelservice-triton.sh: bin/viam-mlmodelservice-triton.sh.envsubst
 	cat $< | TAG=$(TAG) DOLLAR=$$ envsubst > $@
 	chmod +x $@
 

--- a/Makefile.module
+++ b/Makefile.module
@@ -11,16 +11,16 @@ TAG ?= $(URL)$(SUFFIX):$(SEMVER)
 .PHONY: containers container-jetpack5 container-jetpack6 container-cuda
 containers: container-jetpack5 container-jetpack6 container-cuda
 
+container-jetpack5: SUFFIX ?= /jetpack5
 container-jetpack5:
-	TAG ?= $(URL)/jetpack5:$(SEMVER)
 	docker build . -t $(TAG) -f etc/docker/Dockerfile.triton-jetpack-focal
 
+container-jetpack6: SUFFIX ?= /jetpack6
 container-jetpack6:
-	TAG ?= $(URL)/jetpack6:$(SEMVER)
 	docker build . -t $(TAG) -f etc/docker/Dockerfile.nvcr-triton-containers --build-arg JETPACK=1
 
+container-cuda: SUFFIX ?= /cuda
 container-cuda:
-	TAG ?= $(URL)/cuda:$(SEMVER)
 	docker build . -t $(TAG) -f etc/docker/Dockerfile.nvcr-triton-containers
 
 

--- a/bin/viam-mlmodelservice-triton.sh.envsubst
+++ b/bin/viam-mlmodelservice-triton.sh.envsubst
@@ -9,7 +9,7 @@ VIAM_DIR=`realpath ~/.viam`
 # We use `exec` to "become" the docker command. That way, stdout and stderr from the docker command
 # connect to viam-server correctly, and viam-server is able to kill the docker container if needed.
 
-# Sneaky trick alert: we need to get $VIAM_MODULE_DATA propagated into the actual server. If we set
+# Sneaky trick alert: we need to get ${DOLLAR}VIAM_MODULE_DATA propagated into the actual server. If we set
 # the environment variable using a `-e` flag on the docker command, it would be set for the command
 # run, but that command is `sudo`, which does *not* propagate environment variables to its
 # sub-command! So, set it within the `sudo` command at the end.


### PR DESCRIPTION
The targets used in the CI system should be unchanged, but these make it easier to run manually, too. I've done pretty extensive tests of the `module-` targets (and by implication the `.sh` ones), but only cursory tests of the `image-` ones. but the latter all start running docker builds with believable-looking tags!