### PR TITLE
Clean up some small issues

### DIFF
--- a/src/viam_mlmodelservice_triton_impl.cpp
+++ b/src/viam_mlmodelservice_triton_impl.cpp
@@ -196,10 +196,7 @@ class Service : public vsdk::MLModelService, public vsdk::Stoppable, public vsdk
 
         cxxapi::call(cxxapi::the_shim.ServerInferAsync)(
             state->server.get(), inference_request.release(), nullptr);
-
-        auto result2 = inference_future.get();
-        auto inference_response = cxxapi::take_unique(result2);
-
+        auto inference_response = cxxapi::take_unique(inference_future.get());
         auto error = cxxapi::the_shim.InferenceResponseError(inference_response.get());
         if (error) {
             std::ostringstream buffer;
@@ -312,7 +309,6 @@ class Service : public vsdk::MLModelService, public vsdk::Stoppable, public vsdk
 
     struct metadata metadata(const vsdk::AttributeMap& extra) final {
         // Just return a copy of our metadata from leased state.
-        const auto state = lease_state_();
         return lease_state_()->metadata;
     }
 


### PR DESCRIPTION
This should fix the diagnostic you were getting in #29 by ensuring that 1) specializations are declared before first use, which 2) allowed me to eliminate the problematic declaration for `call` which erroneously relied on auto for return type deduction, by 3) placing it after the declarations for the required specializations.

Also, two small changes for leftover debuggging statements.