### PR TITLE
[RSDK-9947] Add markdown_link to meta.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,9 @@ service. Your `model_path` should end up looking something like this:
 ```
 where the `TF2-EfficientDetD0-COCO` is replaced with the name of the model you want to use instead.
 You should also name the model, and add in the name remappings mentioned in the registry entry for
-your model, such as:
+your model.
+
+#### Minimal example
 ```
 {
   "model_path": "${packages.ml_model.TF2-EfficientDetD0-COCO}",
@@ -101,6 +103,7 @@ your model, such as:
   }
 }
 ```
+Remember to select/download the model, so the `model_path` actually exists!
 
 ### Option 2: create a repository to store the ML model to deploy
 

--- a/meta.json
+++ b/meta.json
@@ -7,7 +7,9 @@
   "models": [
     {
       "api": "rdk:service:mlmodel",
-      "model": "viam:mlmodelservice:triton"
+      "model": "viam:mlmodelservice:triton",
+      "short_description": "ML Model Service which interfaces with Triton to do inference",
+      "markdown_link": "README.md#minimal-example"
     }
   ],
   "entrypoint": "viam-mlmodelservice-triton.sh",

--- a/meta.json
+++ b/meta.json
@@ -2,7 +2,7 @@
   "$schema": "https://dl.viam.dev/module.schema.json",
   "module_id": "viam:mlmodelservice-triton-jetpack",
   "visibility": "public",
-  "url": "https://github.com/viamrobotics/viam-mlmodelservice-triton",
+  "url": "https://github.com/viam-modules/viam-mlmodelservice-triton",
   "description": "Viam Triton Inference Server Module",
   "models": [
     {


### PR DESCRIPTION
This currently doesn't show up in the configure tab because the mlmodel services go through a different flow than all the others, but I'm getting a head start so that it's ready. I've done similar work in [multiple](https://github.com/viam-modules/queue-estimator/pull/9) [other](https://github.com/viam-modules/re-id-object-tracking/pull/25) [modules](https://github.com/viam-modules/motion-detector/pull/33), which makes me hopeful that I've done this right.