### PR TITLE
include meta.json in the .tar.gz file

### DIFF
--- a/Makefile.module
+++ b/Makefile.module
@@ -35,7 +35,7 @@ image-cuda:
 
 
 # The module itself.
-module.tar.gz: viam-mlmodelservice-triton.sh first_run.sh
+module.tar.gz: viam-mlmodelservice-triton.sh first_run.sh meta.json
 	tar czf $@ $^
 
 # Helpers for building the module easily. These targets are phony because the files built don't


### PR DESCRIPTION
@JessamyT had questions about first_run scripts in https://github.com/viamrobotics/docs/pull/4187, I went to check on it for her, and got surprised that instead of running `first_run.sh`, this module instead logs `meta.json does not exist, skipping first run` and continues without running it! I've filed https://viam.atlassian.net/browse/RSDK-10382 so it's harder to get into this position next time.

I haven't tried this: local modules don't start up without meta.json, so I think this is only tryable once we deploy to the registry. However, I've run `make -f Makefile.module module.tar.gz` and checked that it successfully puts meta.json in the .tar.gz file.