### PR TITLE
Remove input tensor memory type and device

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ The exact subpath under `~/.viam` does not matter.
 
 > [!NOTE]
 > Where you should place your model repository depends on the `.viam` directory where the cloud config file is located.
-> 
+>
 > You may need to place the model repository in the `/root/.viam` directory for it to work properly, depending on the `.viam` directory you are running from. If you encounter any issues, consider trying the `/root/.viam` directory as an alternative location.
 
 For example, after unpacking the module, to add the [EfficientDet-Lite4 Object Detection](https://tfhub.dev/tensorflow/efficientdet/lite4/detection/2) model, place the model repository under `~/.viam/triton/repository`:
@@ -153,8 +153,6 @@ The following attributes are available for the MLModel service `viam:mlmodelserv
 | `model_path` | string | **Semi-Required** | The directory in which the model to use is stored. You can use strings like `${packages.ml_model.MyModel}`, too. Exactly one of the `model_repository_path` or the `model_path` is required. |
 | `backend_directory` | string | Optional | A container side path to the TritonServer "backend" directory. You normally do not need to override this; the build will set it to the backend directory of the Triton Server installation in the container. You may set it if you wish to use a different set of backends. |
 | `model_version` | int | Optional | The version of the model to be loaded from `model_repository_path`. If not specified, the module will use the newest version of the model named by model_name.<br><br>Default: `-1` (newest) |
-| `preferred_input_memory_type` | string | Optional | One of `cpu`, `cpu-pinned`, or `gpu`. This controlls the type of memory that will be allocated by the module for input tensors. If not specified, this will default to `cpu` if no CUDA-capable devices are detected at runtime, or to `gpu` if CUDA-capable devices are found.|
-| `preferred_input_memory_type_id` | int | Optional | CUDA identifier on which to allocate gpu or cpu-pinned input tensors. You probably don't need to change this unless you have multiple GPUs<br><br>Default: `0` (first device) |
 | `tensor_name_remappings` | obj | Optional | Provides two dictionaries under the `inputs` and `outputs` keys that rename the models' tensors. Other Viam services, like the [vision service]([/ml/vision/](https://docs.viam.com/registry/advanced/mlmodel-design/)) may expect to work with tensors with particular names. Use this map to rename the tensors from the loaded model to what the vision service expects as needed to meet those requirements.<br><br>Default: `{}` |
 
 ### Example configurations
@@ -183,8 +181,6 @@ An example detailed configuration with optional parameters specified would look 
     "model_name": "efficientdet-lite4-detection",
     "model_version": 1,
     "model_path": "${packages.ml_model.FaceDetector}",
-    "preferred_input_memory_type_id": 0,
-    "preferred_input_memory_type": "gpu",
     "tensor_name_remappings": {
       "outputs": {
         "output_3": "n_detections",


### PR DESCRIPTION
It isn't clear that these settings were ever appropriate or meaningful in a single GPU environment, and there is no way to use them correctly in a multi-GPU environment since it is impossible to know which GPU the Triton infrastructure is going to route the request to. It might be useful again in the future, if we had a way for RDK to allocate input tensors (or obtain output tensors) via shared memory regions that could be "on GPU", but as of now we have no ability to do that.