### PR TITLE
Explicitly load models and use app config when applicable

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ The following attributes are available for the MLModel service `viam:mlmodelserv
 | `preferred_input_memory_type` | string | Optional | One of `cpu`, `cpu-pinned`, or `gpu`. This controlls the type of memory that will be allocated by the module for input tensors. If not specified, this will default to `cpu` if no CUDA-capable devices are detected at runtime, or to `gpu` if CUDA-capable devices are found.|
 | `preferred_input_memory_type_id` | int | Optional | CUDA identifier on which to allocate gpu or cpu-pinned input tensors. You probably don't need to change this unless you have multiple GPUs<br><br>Default: `0` (first device) |
 | `tensor_name_remappings` | obj | Optional | Provides two dictionaries under the `inputs` and `outputs` keys that rename the models' tensors. Other Viam services, like the [vision service]([/ml/vision/](https://docs.viam.com/registry/advanced/mlmodel-design/)) may expect to work with tensors with particular names. Use this map to rename the tensors from the loaded model to what the vision service expects as needed to meet those requirements.<br><br>Default: `{}` |
+| `model_config` | obj | Optional | [Triton Model Configuration Parameters](https://docs.nvidia.com/deeplearning/triton-inference-server/user-guide/docs/user_guide/model_configuration.html). If provided, this setting will override any configuration in the configured repository. |
 
 ### Example configurations
 

--- a/src/viam_mlmodelservice_triton.cpp
+++ b/src/viam_mlmodelservice_triton.cpp
@@ -58,6 +58,8 @@ int main(int argc, char* argv[]) {
     cxxapi::the_shim.ErrorDelete = &TRITONSERVER_ErrorDelete;
 
     cxxapi::the_shim.ServerOptionsNew = &TRITONSERVER_ServerOptionsNew;
+    cxxapi::the_shim.ServerOptionsSetModelControlMode =
+        &TRITONSERVER_ServerOptionsSetModelControlMode;
     cxxapi::the_shim.ServerOptionsSetBackendDirectory =
         &TRITONSERVER_ServerOptionsSetBackendDirectory;
     cxxapi::the_shim.ServerOptionsSetLogWarn = &TRITONSERVER_ServerOptionsSetLogWarn;
@@ -71,11 +73,17 @@ int main(int argc, char* argv[]) {
         &TRITONSERVER_ServerOptionsSetStrictModelConfig;
     cxxapi::the_shim.ServerOptionsDelete = &TRITONSERVER_ServerOptionsDelete;
 
+    cxxapi::the_shim.ParameterNew = &TRITONSERVER_ParameterNew;
+    cxxapi::the_shim.ParameterDelete = &TRITONSERVER_ParameterDelete;
+
     cxxapi::the_shim.ServerNew = &TRITONSERVER_ServerNew;
     cxxapi::the_shim.ServerIsLive = &TRITONSERVER_ServerIsLive;
     cxxapi::the_shim.ServerIsReady = &TRITONSERVER_ServerIsReady;
+    cxxapi::the_shim.ServerLoadModel = &TRITONSERVER_ServerLoadModel;
+    cxxapi::the_shim.ServerLoadModelWithParameters = &TRITONSERVER_ServerLoadModelWithParameters;
     cxxapi::the_shim.ServerModelIsReady = &TRITONSERVER_ServerModelIsReady;
     cxxapi::the_shim.ServerInferAsync = &TRITONSERVER_ServerInferAsync;
+    cxxapi::the_shim.ServerUnloadModel = &TRITONSERVER_ServerUnloadModel;
     cxxapi::the_shim.ServerDelete = &TRITONSERVER_ServerDelete;
 
     cxxapi::the_shim.ServerModelMetadata = &TRITONSERVER_ServerModelMetadata;

--- a/src/viam_mlmodelservice_triton.hpp
+++ b/src/viam_mlmodelservice_triton.hpp
@@ -34,6 +34,8 @@ struct shim {
     decltype(TRITONSERVER_ErrorDelete)* ErrorDelete = nullptr;
 
     decltype(TRITONSERVER_ServerOptionsNew)* ServerOptionsNew = nullptr;
+    decltype(TRITONSERVER_ServerOptionsSetModelControlMode)* ServerOptionsSetModelControlMode =
+        nullptr;
     decltype(TRITONSERVER_ServerOptionsSetBackendDirectory)* ServerOptionsSetBackendDirectory =
         nullptr;
     decltype(TRITONSERVER_ServerOptionsSetLogWarn)* ServerOptionsSetLogWarn = nullptr;
@@ -47,11 +49,17 @@ struct shim {
         nullptr;
     decltype(TRITONSERVER_ServerOptionsDelete)* ServerOptionsDelete = nullptr;
 
+    decltype(TRITONSERVER_ParameterNew)* ParameterNew = nullptr;
+    decltype(TRITONSERVER_ParameterDelete)* ParameterDelete = nullptr;
+
     decltype(TRITONSERVER_ServerNew)* ServerNew = nullptr;
     decltype(TRITONSERVER_ServerIsLive)* ServerIsLive = nullptr;
     decltype(TRITONSERVER_ServerIsReady)* ServerIsReady = nullptr;
+    decltype(TRITONSERVER_ServerLoadModel)* ServerLoadModel = nullptr;
+    decltype(TRITONSERVER_ServerLoadModelWithParameters)* ServerLoadModelWithParameters = nullptr;
     decltype(TRITONSERVER_ServerModelIsReady)* ServerModelIsReady = nullptr;
     decltype(TRITONSERVER_ServerInferAsync)* ServerInferAsync = nullptr;
+    decltype(TRITONSERVER_ServerUnloadModel)* ServerUnloadModel = nullptr;
     decltype(TRITONSERVER_ServerDelete)* ServerDelete = nullptr;
 
     decltype(TRITONSERVER_ServerModelMetadata)* ServerModelMetadata = nullptr;
@@ -99,6 +107,9 @@ struct lifecycle_traits<TRITONSERVER_Error>;
 
 template <>
 struct lifecycle_traits<TRITONSERVER_ServerOptions>;
+
+template <>
+struct lifecycle_traits<TRITONSERVER_Parameter>;
 
 template <>
 struct lifecycle_traits<TRITONSERVER_Server>;
@@ -190,6 +201,19 @@ struct lifecycle_traits<TRITONSERVER_ServerOptions> {
     template <class... Args>
     static auto dtor(Args&&... args) {
         call(the_shim.ServerOptionsDelete)(std::forward<Args>(args)...);
+    }
+};
+
+template <>
+struct lifecycle_traits<TRITONSERVER_Parameter> {
+    using value_type = TRITONSERVER_Parameter;
+    template <class... Args>
+    static auto ctor(Args&&... args) {
+        return (the_shim.ParameterNew)(std::forward<Args>(args)...);
+    }
+    template <class... Args>
+    static auto dtor(Args&&... args) {
+        (the_shim.ParameterDelete)(std::forward<Args>(args)...);
     }
 };
 

--- a/src/viam_mlmodelservice_triton_impl.cpp
+++ b/src/viam_mlmodelservice_triton_impl.cpp
@@ -31,6 +31,9 @@
 #include <stack>
 #include <stdexcept>
 
+#include <google/protobuf/struct.pb.h>
+#include <google/protobuf/util/json_util.h>
+
 #include <grpcpp/channel.h>
 #include <grpcpp/create_channel.h>
 #include <grpcpp/security/credentials.h>
@@ -619,7 +622,71 @@ class Service : public vsdk::MLModelService, public vsdk::Stoppable, public vsdk
         cxxapi::call(cxxapi::the_shim.ServerOptionsSetStrictModelConfig)(server_options.get(),
                                                                          false);
 
+        // We will load models on demand, rather than having Triton
+        // auto-load everything it finds in the repository. When
+        // triton auto-loads models, the only way to provide model
+        // configuration state is by placing that data inside the
+        // repository. By using explicit model control, we take over
+        // that responsibility, and can overwrite or provide
+        // configuration by calling
+        // `TRITONSERVER_LoadModelWithParameters`.
+        cxxapi::call(cxxapi::the_shim.ServerOptionsSetModelControlMode)(
+            server_options.get(), TRITONSERVER_MODEL_CONTROL_EXPLICIT);
+
         auto server = cxxapi::make_unique<TRITONSERVER_Server>(server_options.get());
+
+        // If the attributes contain a `model_config` section, use
+        // `ServerLoadModelWithParameters` in order to set additional
+        // model parameters per the Triton model repository
+        // configuration. Note that if set, these values will override
+        // any found in the model repository.
+
+        const auto model_config = attributes.find("model_config");
+        if (model_config != attributes.end()) {
+            // Make sure the `model_config` attribute is a document.
+            const auto model_config_attributes = model_config->second.get<vsdk::ProtoStruct>();
+            if (!model_config_attributes) {
+                std::ostringstream buffer;
+                buffer << service_name
+                       << ": Optional parameter `model_config` must be a dictionary";
+                throw std::invalid_argument(buffer.str());
+            }
+
+            // Convert the C++ SDK `ProtoStruct` back to a protobuf
+            // `Struct` so we can use the protobuf utilities to get it
+            // as a JSON string.
+            const auto model_config_struct = vsdk::to_proto(*model_config_attributes);
+
+            std::string model_config_json;
+            const auto model_config_json_status = google::protobuf::util::MessageToJsonString(
+                model_config_struct, &model_config_json, {});
+
+            if (!model_config_json_status.ok()) {
+                std::ostringstream buffer;
+                buffer << service_name
+                       << ": Optional parameter `model_config` failed conversion to JSON: "
+                       << model_config_json_status.ToString();
+                throw std::invalid_argument(buffer.str());
+            }
+
+            // The `TRITONSERVER_ServerLoadModelWithParameters`
+            // function expects a `TRITONSERVER_Parameter` of string
+            // type named `config` to contain the model configuration
+            // JSON.
+            const auto parameter = cxxapi::make_unique<TRITONSERVER_Parameter>(
+                "config", TRITONSERVER_PARAMETER_STRING, model_config_json.c_str());
+
+            // Stash the parameter in an array of pointers since
+            // TRITONSERVER_LoadModelWithParameters wants a
+            // pointer to array for the third argument.
+            std::array<const TRITONSERVER_Parameter*, 1> parameters = {parameter.get()};
+            cxxapi::call(cxxapi::the_shim.ServerLoadModelWithParameters)(
+                server.get(), state->model_name.c_str(), parameters.data(), parameters.size());
+        } else {
+            // TODO: Maybe we can always use `TRITONSERVER_LoadModelWithParameters` but pass no
+            // parameters?
+            cxxapi::call(cxxapi::the_shim.ServerLoadModel)(server.get(), state->model_name.c_str());
+        }
 
         // TODO(RSDK-4663): For now, we are hardcoding a wait that is
         // a subset of the RDK default timeout.


### PR DESCRIPTION
By default, Triton loads all models in a given repository. If the model has a configuration file in the repository, that configuration is used. If no configuration is provided, the default is to load one copy of each model on every GPU in the system.

However, it is also possible to put Triton into "explicit" model mode, where it doesn't load any models by default when a server is instantiated with a given repository, and instead relies on manual model loading. As it happens, that manual model loading path can accept a JSON configuration parameter, and that, in turn allows us to set configuration parameters for models in the app configuration. For instance, the `model_config` in the following configuration fragment:

```
  "services": [
    {
      "name": "mlmodel-triton-1",
      "api": "rdk:service:mlmodel",
      "model": "viam:mlmodelservice:triton",
      "attributes": {
        "package_reference": "e76d1b3b-0468-4efd-bb7f-fb1d2b352fcb/TF2-EfficientDetD0-COCO",
        "model_name": "TF2-EfficientDetD0-COCO",
        "model_path": "${packages.ml_model.TF2-EfficientDetD0-COCO}",
        "model_config": {
          "instance_group": [
            {
              "count": 2,
              "kind": "KIND_GPU",
              "gpus": [
                0,
                1
              ]
            }
          ],
          "dynamic_batching": {
            "max_queue_delay_microseconds": 100000
          }
        },
```