### PR TITLE
Explicitly attach desired outputs to inference requests

### DIFF
--- a/src/viam_mlmodelservice_triton.cpp
+++ b/src/viam_mlmodelservice_triton.cpp
@@ -97,6 +97,8 @@ int main(int argc, char* argv[]) {
     cxxapi::the_shim.InferenceRequestAddInput = &TRITONSERVER_InferenceRequestAddInput;
     cxxapi::the_shim.InferenceRequestAppendInputData =
         &TRITONSERVER_InferenceRequestAppendInputData;
+    cxxapi::the_shim.InferenceRequestAddRequestedOutput =
+        &TRITONSERVER_InferenceRequestAddRequestedOutput;
     cxxapi::the_shim.InferenceRequestSetResponseCallback =
         &TRITONSERVER_InferenceRequestSetResponseCallback;
     cxxapi::the_shim.InferenceRequestDelete = &TRITONSERVER_InferenceRequestDelete;

--- a/src/viam_mlmodelservice_triton.hpp
+++ b/src/viam_mlmodelservice_triton.hpp
@@ -73,6 +73,8 @@ struct shim {
     decltype(TRITONSERVER_InferenceRequestAddInput)* InferenceRequestAddInput = nullptr;
     decltype(TRITONSERVER_InferenceRequestAppendInputData)* InferenceRequestAppendInputData =
         nullptr;
+    decltype(TRITONSERVER_InferenceRequestAddRequestedOutput)* InferenceRequestAddRequestedOutput =
+        nullptr;
     decltype(TRITONSERVER_InferenceRequestSetResponseCallback)*
         InferenceRequestSetResponseCallback = nullptr;
     decltype(TRITONSERVER_InferenceRequestDelete)* InferenceRequestDelete = nullptr;


### PR DESCRIPTION
I think this was a (currently) harmless oversight, where we weren't actually telling the Triton server which outputs we wanted back on inference. It appears to default then to returning them all, and, since we return all outputs in our metadata, it was effectively equivalent. But I wanted to clean this up, since the API we use to detach the outputs from the request before reusing it is `InferenceRequestRemoveAllRequestedOutputs`, and I'm more comfortable with things if we are aren't relying on defaulted behavior which could potentially change in a future version of Triton: it just feels better to be explicit about which outputs we want. I can also see a future where we may want to limit the set of outputs. A model might have an expensive to transfer output that we don't want sent over the wire because we know the consumer doesn't need it. With this step included, it would be easier to later add that filter here.